### PR TITLE
Added possibility to disable tracking

### DIFF
--- a/Controller/GAController.php
+++ b/Controller/GAController.php
@@ -13,6 +13,17 @@ class GAController extends Controller
             array(
                 'account' => $this->getParameter('ga_tracking.account'),
                 'debug'   => $this->getParameter('ga_tracking.debug'),
+                'enabled'   => $this->getParameter('ga_tracking.enabled'),
+            )
+        );
+    }
+
+    public function renderStartAction()
+    {
+        return $this->render(
+            'HamaryuginhGoogleAnalyticsBundle:GA:start_ga.html.twig',
+            array(
+                'enabled'   => $this->getParameter('ga_tracking.enabled'),
             )
         );
     }

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -28,6 +28,9 @@ class Configuration implements ConfigurationInterface
                 ->booleanNode('debug')
                     ->defaultValue(false)
                 ->end()
+                ->booleanNode('enabled')
+                    ->defaultValue(true)
+                ->end()
             ->end()
         ;
 

--- a/DependencyInjection/HamaryuginhGoogleAnalyticsExtension.php
+++ b/DependencyInjection/HamaryuginhGoogleAnalyticsExtension.php
@@ -25,6 +25,7 @@ class HamaryuginhGoogleAnalyticsExtension extends Extension
         $container->setParameter('ga_tracking', $config);
         $container->setParameter('ga_tracking.account', $config['account']);
         $container->setParameter('ga_tracking.debug', $config['debug']);
+        $container->setParameter('ga_tracking.enabled', $config['enabled']);
 
         $loader = new Loader\XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.xml');

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Add to your `app/config/config.yml` the following:
 hamaryuginh_google_analytics:
     account: UA-XXXXXX-Y   # Your GA account ID
     debug:   false         # [Facultative] set to true to activate debug mode
+    enabled: false         # Enable or disable tracking
 ```
 
 Add to your `app/config/routing.yml` the following:
@@ -59,10 +60,8 @@ Add the following before `</head>` tag:
 
 At the end of your document, before the `</body>` tag, add:
 
-```html
-<script type="text/javascript">
-    gat.go();
-</script>
+```twig
+{{ render(controller('HamaryuginhGoogleAnalyticsBundle:GA:renderStart')) }}
 ```
 
 Install assets (from your symfony project root):

--- a/Resources/views/GA/render.html.twig
+++ b/Resources/views/GA/render.html.twig
@@ -1,7 +1,14 @@
-{#<!-- Google Analytics -->#}
-<script src="{{ asset('bundles/hamaryuginhgoogleanalytics/js/tracking.min.js') }}"></script>
-{#<script src="{{ asset('bundles/hamaryuginhgoogleanalytics/js/tracking.js') }}"></script>#}
-<script type="text/javascript">
-    gat.init('{{ account }}', {{ debug ? 'true' : 'false' }});
-</script>
-{#<!-- End Google Analytics -->#}
+{% extends "HamaryuginhGoogleAnalyticsBundle:Global:render.html.twig" %}
+
+{% block script %}
+
+    {#<!-- Google Analytics -->#}
+    <script src="{{ asset('bundles/hamaryuginhgoogleanalytics/js/tracking.min.js') }}"></script>
+    {#<script src="{{ asset('bundles/hamaryuginhgoogleanalytics/js/tracking.js') }}"></script>#}
+    <script type="text/javascript">
+        gat.init('{{ account }}', {{ debug ? 'true' : 'false' }});
+    </script>
+    {#<!-- End Google Analytics -->#}
+
+
+{% endblock %}

--- a/Resources/views/GA/start_ga.html.twig
+++ b/Resources/views/GA/start_ga.html.twig
@@ -1,0 +1,9 @@
+{% extends "HamaryuginhGoogleAnalyticsBundle:Global:render.html.twig" %}
+
+{% block script %}
+
+    <script type="text/javascript">
+        gat.go();
+    </script>
+
+{% endblock %}

--- a/Resources/views/Global/render.html.twig
+++ b/Resources/views/Global/render.html.twig
@@ -1,0 +1,6 @@
+{% if (enabled == true) %}
+
+    {% block script %}
+    {% endblock %}
+
+{% endif %}


### PR DESCRIPTION
I don't know if it was the cleanest way to do it but it works...

Now you are able in _config_dev.yml_ to write : 

``` yaml
hamaryuginh_google_analytics:
    account: UA-XXXXXX-Y   # Your GA account ID
    debug:   false         # [Facultative] set to true to activate debug mode
    enabled: false         # Enable or disable tracking
```

and in _config_prod.yml_ : 

``` yaml
hamaryuginh_google_analytics:
    account: UA-XXXXXX-Y   # Your GA account ID
    debug:   false         # [Facultative] set to true to activate debug mode
    enabled: true         # Enable or disable tracking
```
